### PR TITLE
Correct the nonce typo

### DIFF
--- a/sscoin.js
+++ b/sscoin.js
@@ -14,16 +14,16 @@ class Block {
         this.transactions = transactions;
         this.previousHash = previousHash;
         this.hash = this.calculateHash();
-        this.nonse = 0;
+        this.nonce = 0;
     }
 
     calculateHash() {
-        return SHA256(this.previousHash + this.timestamp + JSON.stringify(this.transactions) + this.nonse).toString();
+        return SHA256(this.previousHash + this.timestamp + JSON.stringify(this.transactions) + this.nonce).toString();
     }
 
     mineBlock(difficulty) {
         while(this.hash.substring(0, difficulty) != Array(difficulty + 1).join("0")) {
-            this.nonse++;
+            this.nonce++;
             this.hash = this.calculateHash();
         }
 


### PR DESCRIPTION
Hi @Saurabh3333.

I was going through [sscoin](https://github.com/Saurabh3333/sscoin/blob/master/sscoin.js) and found a typo viz. 'nonse' was  written instead of '[nonce](https://en.wikipedia.org/wiki/Cryptographic_nonce)'. I've updated the file and have corrected the typo.

Please review and merge the PR, in case there isn't any issue.

Regards
Shrish