### PR TITLE
Correct the nonce typo in block.js file

### DIFF
--- a/block.js
+++ b/block.js
@@ -7,16 +7,16 @@ class Block {
         this.data = data;
         this.previousHash = previousHash;
         this.hash = '';
-        this.nonse = 0;
+        this.nonce = 0;
     }
 
     calculateHash() {
-        return SHA256(this.index + this.previousHash + this.timestamp + JSON.stringify(this.data) + this.nonse).toString();
+        return SHA256(this.index + this.previousHash + this.timestamp + JSON.stringify(this.data) + this.nonce).toString();
     }
 
     mineBlock(difficulty) {
         while(this.hash.substring(0, difficulty) != Array(difficulty + 1).join("0")) {
-            this.nonse++;
+            this.nonce++;
             this.hash = this.calculateHash();
         }
 


### PR DESCRIPTION
Hi @Saurabh3333.

I was going through [block.js](https://github.com/Saurabh3333/sscoin/blob/master/block.js) and found a typo viz. 'nonse' written instead of '[nonce](https://en.wikipedia.org/wiki/Cryptographic_nonce)'. I've updated the file and have corrected the typo.

Please review and merge the PR, in case there isn't any issue.

Regards
Shrish